### PR TITLE
Update `npm test` to exclude lib/bs/tests files

### DIFF
--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/change/package.json
+++ b/exercises/practice/change/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/eliuds-eggs/package.json
+++ b/exercises/practice/eliuds-eggs/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/prism/package.json
+++ b/exercises/practice/prism/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "res:start": "rescript build -w",
     "res:format-check": "rescript format --check",
     "res:format-fix": "rescript format",
-    "test": "rescript && retest **/tests/*.js",
+    "test": "rescript && retest tests/*.js",
     "ci": "npm test"
   }
 }


### PR DESCRIPTION
When I was writing up the test docs, I used Two-Fer for an example and noticed `npm test` was detecting six tests when only three were defined in the test suite.