### PR TITLE
Add stale problem-specs CI

### DIFF
--- a/.github/workflows/check-problem-specs-is-current.yml
+++ b/.github/workflows/check-problem-specs-is-current.yml
@@ -1,0 +1,21 @@
+name: Check Problem Specifications is Current
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check_problem_specifications:
+    name: Check problem specifications
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Check problem-specifications is current
+        run: bin/check-problem-specs-is-current

--- a/bin/check-problem-specs-is-current
+++ b/bin/check-problem-specs-is-current
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Synopsis:
+# Verify that the problem-specifications submodule is up-to-date with the latest upstream commit.
+
+set -euo pipefail
+
+latest_commit="$(git ls-remote https://github.com/exercism/problem-specifications.git refs/heads/main | cut -f1)"
+
+if [[ -z "$latest_commit" ]]; then
+  echo "::error:: Could not determine latest upstream problem-specifications commit."
+  exit 1
+fi
+
+current_commit="$(git rev-parse HEAD:problem-specifications)"
+
+if [[ "$current_commit" != "$latest_commit" ]]; then
+  echo "::error:: The problem-specifications submodule is out of date. Update it to ${latest_commit}."
+  exit 1
+fi
+
+echo "The problem-specifications submodule is current at ${current_commit}."


### PR DESCRIPTION
This should flag when the problem-specifications submodule isn't up-to-date on a PR.