### PR TITLE
CI for checking generated suites in sync with templates

### DIFF
--- a/.github/workflows/check-generated-tests-in-sync.yml
+++ b/.github/workflows/check-generated-tests-in-sync.yml
@@ -1,0 +1,35 @@
+name: Check Generated Tests In Sync
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "test_generator/**"
+      - "test_templates/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check_generated_tests:
+    name: Check generated tests in sync
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: true
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check generated tests in sync
+        run: bin/check-generated-tests-in-sync

--- a/bin/check-generated-tests-in-sync
+++ b/bin/check-generated-tests-in-sync
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Synopsis:
+# Check that test suites are in sync with their current templates.
+
+set -euo pipefail
+
+npm run res:build
+make generate-tests
+
+if [[ -n "$(git status --porcelain -- exercises/practice)" ]]; then
+  echo "::error:: Generated test template output does not match committed test output."
+  git status --short -- exercises/practice
+  git diff -- exercises/practice
+  exit 1
+fi
+
+echo "Generated test template output matches committed test output."


### PR DESCRIPTION
This CI validates whether the current templates and their outputs match what's already been committed. The intention is mainly to catch an issue where the test generator or templates are updated but not rerun.