### PR TITLE
Remove workflow file from triggers

### DIFF
--- a/.github/workflows/check-problem-specs-is-current.yml
+++ b/.github/workflows/check-problem-specs-is-current.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - ".github/workflows/check-problem-specs-is-current.yml"
       - "bin/check-problem-specs-is-current"
       - "problem-specifications"
       - "problem-specifications/**"


### PR DESCRIPTION
Related to #57. If we trigger the problem specs CI run when the YAML file is touched, it'll run every time Dependabot bumps it. That's a bit noisy so I'll remove the file from the CI triggers.